### PR TITLE
fix: ssl support - getops

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -2,5 +2,5 @@
   {"lib/diode_client/cowboy2_adapter.ex:0:unknown_function Function Plug.Cowboy.child_spec/1 does not exist."},
   {"lib/diode_client/cowboy2_adapter.ex:41:unknown_function Function Plug.Cowboy.child_spec/1 does not exist."},
   {"lib/diode_client/transport.ex:0:unknown_function Function :ranch_transport.sendfile/6 does not exist."},
-  {"lib/diode_client/transport.ex:49:unknown_function Function :ranch_transport.sendfile/6 does not exist."}
+  {"lib/diode_client/transport.ex:50:unknown_function Function :ranch_transport.sendfile/6 does not exist."}
 ]

--- a/lib/diode_client/transport.ex
+++ b/lib/diode_client/transport.ex
@@ -39,6 +39,7 @@ defmodule DiodeClient.Transport do
   defdelegate controlling_process(pid, dst), to: :ssl
   defdelegate peername(pid), to: :ssl
   defdelegate setopts(pid, opts), to: :ssl
+  defdelegate getopts(pid, opts), to: :ssl
   defdelegate send(pid, data), to: :ssl
   defdelegate recv(pid, length), to: :ssl
   defdelegate recv(pid, length, timeout), to: :ssl


### PR DESCRIPTION
Fixes `** (UndefinedFunctionError) function DiodeClient.Transport.getopts/2 is undefined or private`