### PR TITLE
Fix local port discovery on Windows when ipconfig is missing

### DIFF
--- a/lib/diode_client/local_acceptor.ex
+++ b/lib/diode_client/local_acceptor.ex
@@ -122,9 +122,7 @@ defmodule DiodeClient.LocalAcceptor do
           ~r/IPv4.+ (([0-9]{1,3}\.){3}([0-9]{1,3}))/
 
         :inet6 ->
-          ~r/IPv4.+ (([0-9]{1,3}\.){3}([0-9]{1,3}))/
-          # TODO
-          # :inet6 -> ~r/IPv6.+ (([0-9]{1,3}\.){3}([0-9]{1,3}))/
+          ~r/IPv6.+ (([a-f0-9:]+:+)+[a-f0-9]+)/i
       end
 
     with {:ok, ret} <- run_ipconfig(),

--- a/lib/diode_client/local_acceptor.ex
+++ b/lib/diode_client/local_acceptor.ex
@@ -97,21 +97,29 @@ defmodule DiodeClient.LocalAcceptor do
     case :inet.getifaddrs() do
       {:ok, ifs} ->
         Enum.find_value(ifs, fn {_name, props} ->
-          flags = Keyword.get(props, :flags, [])
-
-          if :up in flags and :running in flags and :loopback not in flags do
-            props
-            |> Keyword.get_values(:addr)
-            |> Enum.find(fn addr -> is_tuple(addr) and tuple_size(addr) == expected_size end)
-            |> case do
-              nil -> nil
-              addr -> List.to_string(:inet.ntoa(addr))
-            end
-          end
+          inet_getifaddrs_props_address(props, expected_size)
         end)
 
       _ ->
         nil
+    end
+  end
+
+  defp inet_getifaddrs_props_address(props, expected_size) do
+    flags = Keyword.get(props, :flags, [])
+
+    if :up in flags and :running in flags and :loopback not in flags do
+      inet_getifaddrs_first_addr(props, expected_size)
+    end
+  end
+
+  defp inet_getifaddrs_first_addr(props, expected_size) do
+    props
+    |> Keyword.get_values(:addr)
+    |> Enum.find(fn addr -> is_tuple(addr) and tuple_size(addr) == expected_size end)
+    |> case do
+      nil -> nil
+      addr -> List.to_string(:inet.ntoa(addr))
     end
   end
 

--- a/lib/diode_client/local_acceptor.ex
+++ b/lib/diode_client/local_acceptor.ex
@@ -54,23 +54,7 @@ defmodule DiodeClient.LocalAcceptor do
   def local_address(family) do
     case :os.type() do
       {:win32, _} ->
-        {ret, 0} = System.cmd("ipconfig", [])
-
-        regex =
-          case family do
-            :inet ->
-              ~r/IPv4.+ (([0-9]{1,3}\.){3}([0-9]{1,3}))/
-
-            :inet6 ->
-              ~r/IPv4.+ (([0-9]{1,3}\.){3}([0-9]{1,3}))/
-              # TODO
-              # :inet6 -> ~r/IPv6.+ (([0-9]{1,3}\.){3}([0-9]{1,3}))/
-          end
-
-        case Regex.run(regex, ret) do
-          nil -> nil
-          [_ret, match | _rest] -> match
-        end
+        windows_local_address(family)
 
       {:unix, _} ->
         case :net.getifaddrs() do
@@ -89,6 +73,87 @@ defmodule DiodeClient.LocalAcceptor do
             nil
         end
     end
+  end
+
+  # On Windows :net.getifaddrs/0 is not available, so we first try the
+  # cross-platform :inet.getifaddrs/0 (no subprocess required) and only
+  # fall back to parsing `ipconfig` output if that returns nothing usable.
+  # Some Windows installs don't have `ipconfig` on PATH, so we try the
+  # absolute System32 path first.
+  defp windows_local_address(family) do
+    case inet_getifaddrs_pick(family) do
+      nil -> windows_ipconfig_address(family)
+      address -> address
+    end
+  end
+
+  defp inet_getifaddrs_pick(family) do
+    expected_size =
+      case family do
+        :inet -> 4
+        :inet6 -> 8
+      end
+
+    case :inet.getifaddrs() do
+      {:ok, ifs} ->
+        Enum.find_value(ifs, fn {_name, props} ->
+          flags = Keyword.get(props, :flags, [])
+
+          if :up in flags and :running in flags and :loopback not in flags do
+            props
+            |> Keyword.get_values(:addr)
+            |> Enum.find(fn addr -> is_tuple(addr) and tuple_size(addr) == expected_size end)
+            |> case do
+              nil -> nil
+              addr -> List.to_string(:inet.ntoa(addr))
+            end
+          end
+        end)
+
+      _ ->
+        nil
+    end
+  end
+
+  defp windows_ipconfig_address(family) do
+    regex =
+      case family do
+        :inet ->
+          ~r/IPv4.+ (([0-9]{1,3}\.){3}([0-9]{1,3}))/
+
+        :inet6 ->
+          ~r/IPv4.+ (([0-9]{1,3}\.){3}([0-9]{1,3}))/
+          # TODO
+          # :inet6 -> ~r/IPv6.+ (([0-9]{1,3}\.){3}([0-9]{1,3}))/
+      end
+
+    with {:ok, ret} <- run_ipconfig(),
+         [_ret, match | _rest] <- Regex.run(regex, ret) do
+      match
+    else
+      _ -> nil
+    end
+  end
+
+  defp run_ipconfig() do
+    Enum.find_value(ipconfig_candidates(), fn path ->
+      with exe when is_binary(exe) <- System.find_executable(path),
+           {out, 0} <- System.cmd(exe, []) do
+        {:ok, out}
+      else
+        _ -> nil
+      end
+    end)
+  end
+
+  defp ipconfig_candidates() do
+    system_root = System.get_env("SystemRoot") || System.get_env("WINDIR") || "C:\\Windows"
+
+    Enum.uniq([
+      Path.join([system_root, "System32", "ipconfig.exe"]),
+      "C:\\Windows\\System32\\ipconfig.exe",
+      "ipconfig"
+    ])
   end
 
   @tls_timeout 5_000

--- a/test/rlpx_test.exs
+++ b/test/rlpx_test.exs
@@ -27,6 +27,8 @@ defmodule DiodeClientRlpxTest do
   end
 
   test "failed decode" do
-    assert DiodeClient.Base16.decode("0xbe3afef029034d72de7a30908d95c747") |> DiodeClient.Rlp.decode() == {:error, "RLP decode: string length 16605856082906482 exceeds maximum 8"}
+    assert DiodeClient.Base16.decode("0xbe3afef029034d72de7a30908d95c747")
+           |> DiodeClient.Rlp.decode() ==
+             {:error, "RLP decode: string length 16605856082906482 exceeds maximum 8"}
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,7 @@
 # Start Anvil in background so :anvil tests run; if Foundry is not installed or Anvil
 # fails to start, exclude :anvil tests so mix test still passes.
+require Logger
+
 case DiodeClient.Anvil.Helper.start_anvil() do
   {:ok, _} ->
     DiodeClient.Anvil.Helper.ensure_test_env(wallet: "test_anvil", deploy_contracts: true)


### PR DESCRIPTION
## Problem

Some Windows systems don't have `ipconfig.exe` on `PATH`, which causes `DiodeClient.LocalAcceptor.local_address/1` to crash on:

```elixir
{ret, 0} = System.cmd("ipconfig", [])
```

When this crashes inside the `local_port` GenServer call, the client can't advertise a local IP and direct P2P connections silently fall back to relay.

Reported in diodechain/ddrive#930 (medium impact: relay still works, direct connect doesn't).

## Fix

1. Prefer the cross-platform `:inet.getifaddrs/0` (already part of `erts`, no subprocess required, works on Linux, macOS, **and Windows**).
2. Only fall back to parsing `ipconfig` output if `:inet.getifaddrs/0` returns no usable interface.
3. When parsing `ipconfig`, resolve the binary explicitly via `%SystemRoot%\System32\ipconfig.exe` (and the canonical `C:\Windows\System32\ipconfig.exe` path) before trying the bare `"ipconfig"` lookup.
4. Use `System.find_executable/1` so a missing binary returns `nil` instead of raising.

The Linux/macOS code path is unchanged.

## Notes / alternatives considered

- `:net.getifaddrs/0` (the newer OTP API the unix branch uses) is **not implemented on Windows** today, so we keep the `:os.type/0` split and use the older `:inet` API on Windows only.
- Always preferring `:inet.getifaddrs/0` (also on unix) would work, but it's a riskier change and unrelated to this bug. The fix is intentionally scoped.