### PR TITLE
Anvil helper: ignore unrelated EXIT while awaiting port

### DIFF
--- a/lib/diode_client/anvil/helper.ex
+++ b/lib/diode_client/anvil/helper.ex
@@ -229,6 +229,10 @@ defmodule DiodeClient.Anvil.Helper do
         # IO.puts("exit:epipe")
         exit(:normal)
 
+      # Ignore EXIT signals from unrelated linked processes during teardown (trap_exit).
+      {:EXIT, _, _} ->
+        await_exit_status(creator, port, data)
+
       {^port, {:data, new_data}} ->
         # IO.puts(new_data)
         data = data <> new_data

--- a/lib/diode_client/anvil/helper.ex
+++ b/lib/diode_client/anvil/helper.ex
@@ -229,7 +229,11 @@ defmodule DiodeClient.Anvil.Helper do
         # IO.puts("exit:epipe")
         exit(:normal)
 
-      # Ignore EXIT signals from unrelated linked processes during teardown (trap_exit).
+      # Exit if the creator process dies to avoid leaking the watcher and Anvil port.
+      {:EXIT, ^creator, _reason} ->
+        exit(:normal)
+
+      # Ignore EXIT signals from other unrelated linked processes during teardown.
       {:EXIT, _, _} ->
         await_exit_status(creator, port, data)
 


### PR DESCRIPTION
## Summary

`DiodeClient.Anvil.Helper.start_anvil/1` runs `await_exit_status/3` in a `spawn_link` watcher with `Process.flag(:trap_exit, true)`. With `:trap_exit`, the process receives `{:EXIT, pid, reason}` for exits of **linked** processes, not only the Anvil Port.

Those unrelated `EXIT` messages matched none of the `case` clauses built around the `receive`, surfaced as **CaseClauseError** during teardown in downstream CI (scenario / Playwright runs).

## Change

Add a `{:EXIT, _, _}` clause that recurses into `await_exit_status(creator, port, data)`, matching the mitigation previously applied out-of-band in `ddrive`'s `scripts/patch_diode_anvil_helper.sh` shim.

Once this ships, downstream can drop that shim and bump the `:diode_client` dependency.