### PR TITLE
Fix CaseClauseError in OasisSapphire.get_meta_nonce/3 on RPC errors

### DIFF
--- a/lib/diode_client/shell/oasis_sapphire.ex
+++ b/lib/diode_client/shell/oasis_sapphire.ex
@@ -47,11 +47,13 @@ defmodule DiodeClient.Shell.OasisSapphire do
     if meta_transaction do
       wallet = DiodeClient.ensure_wallet()
       from = Wallet.address!(wallet)
-      nonce = Keyword.get(opts, :nonce) || get_meta_nonce(from, peak(), opts)
 
-      create_meta_transaction(address, function_name, types, values, nonce, opts)
-      # |> MetaTransaction.simulate(__MODULE__)
-      |> send_transaction()
+      with nonce when is_integer(nonce) <-
+             Keyword.get(opts, :nonce) || get_meta_nonce(from, peak(), opts),
+           meta_tx <-
+             create_meta_transaction(address, function_name, types, values, nonce, opts) do
+        send_transaction(meta_tx)
+      end
     else
       create_transaction(address, function_name, types, values, opts)
       |> send_transaction()
@@ -79,13 +81,25 @@ defmodule DiodeClient.Shell.OasisSapphire do
       block: peak,
       result_types: "uint"
     )
-    |> case do
+    |> meta_nonce_from_call(id)
+  end
+
+  @doc false
+  def meta_nonce_from_call(result, identity) do
+    case result do
       nonce when is_integer(nonce) ->
         nonce
 
       :revert ->
-        Logger.warning("Identity contract at #{DiodeClient.Base16.encode(id)} reverted")
+        Logger.warning("Identity contract at #{DiodeClient.Base16.encode(identity)} reverted")
         0
+
+      {:error, _} = error ->
+        Logger.warning(
+          "get_meta_nonce: nonce lookup for #{DiodeClient.Base16.encode(identity)} failed: #{inspect(elem(error, 1))}"
+        )
+
+        error
     end
   end
 

--- a/test/oasis_sapphire_test.exs
+++ b/test/oasis_sapphire_test.exs
@@ -1,0 +1,57 @@
+defmodule DiodeClient.Shell.OasisSapphireTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias DiodeClient.Shell.OasisSapphire
+
+  @identity <<0xAB::160>>
+
+  @rpc_error %{
+    "code" => -32000,
+    "message" => "invalid signed simulate call query: base block not found"
+  }
+
+  describe "meta_nonce_from_call/2" do
+    test "returns integer nonce unchanged" do
+      assert OasisSapphire.meta_nonce_from_call(7, @identity) == 7
+    end
+
+    test "returns 0 when the identity contract reverts" do
+      log =
+        capture_log(fn ->
+          assert OasisSapphire.meta_nonce_from_call(:revert, @identity) == 0
+        end)
+
+      assert log =~ "reverted"
+    end
+
+    test "returns {:error, reason} for transient Sapphire RPC failures" do
+      log =
+        capture_log(fn ->
+          assert OasisSapphire.meta_nonce_from_call({:error, @rpc_error}, @identity) ==
+                   {:error, @rpc_error}
+        end)
+
+      assert log =~ "get_meta_nonce: nonce lookup"
+      assert log =~ "base block not found"
+    end
+  end
+
+  describe "send_transaction/5 meta_transaction nonce errors" do
+    test "returns {:error, _} when nonce lookup fails" do
+      result =
+        OasisSapphire.send_transaction(
+          <<0::160>>,
+          "Version",
+          [],
+          [],
+          meta_transaction: true,
+          nonce: {:error, @rpc_error},
+          identity: @identity
+        )
+
+      assert {:error, @rpc_error} = result
+    end
+  end
+end


### PR DESCRIPTION
## What

Fixes the root cause of `CaseClauseError` crashes in `DiodeClient.Shell.OasisSapphire.get_meta_nonce/3` when the Sapphire RPC node returns a transient error such as `invalid signed simulate call query: base block not found`.

Related downstream fix: https://github.com/diodechain/ddrive/pulls (ddrive `Model.App.update_nonce/2` workaround can be removed once this ships and `mix.lock` is bumped).

## Root cause

`oasis_call/2` can return `{:error, reason}` when the RPC rejects a simulated call, but `get_meta_nonce/3` only matched on integer nonces and `:revert`. The missing clause raised `CaseClauseError`, which propagated through callers like `UserMonitor.update_user/2`.

## Change

- **`get_meta_nonce/3`**: handle `{:error, reason}` via `meta_nonce_from_call/2` — log a warning and return `{:error, reason}` instead of crashing.
- **`send_transaction/5`** (meta-transaction path): use `with` so a failed nonce lookup returns `{:error, reason}` instead of passing a bad value into `create_meta_transaction/6`.

## Tests

`test/oasis_sapphire_test.exs` covers:

1. `meta_nonce_from_call/2` returns integer nonces unchanged
2. `:revert` returns `0` with a warning
3. The exact RPC error from production reports returns `{:error, reason}` with a warning (no raise)
4. `send_transaction/5` propagates `{:error, reason}` when nonce lookup fails

```
$ mix test test/oasis_sapphire_test.exs
4 tests, 0 failures
```