### PR TITLE
fix: Ignore unrelated EXIT signals in Anvil helper

### DIFF
--- a/lib/diode_client/anvil/helper.ex
+++ b/lib/diode_client/anvil/helper.ex
@@ -229,6 +229,10 @@ defmodule DiodeClient.Anvil.Helper do
         # IO.puts("exit:epipe")
         exit(:normal)
 
+      # Ignore EXIT signals from unrelated linked processes during teardown (trap_exit).
+      {:EXIT, _, _} ->
+        await_exit_status(creator, port, data)
+
       {^port, {:data, new_data}} ->
         # IO.puts(new_data)
         data = data <> new_data


### PR DESCRIPTION
This ignores EXIT signals from unrelated linked processes during teardown (trap_exit) in the Anvil helper.

Made with [Cursor](https://cursor.com)