### PR TITLE
Fix Dialyzer CI failures on latest OTP

### DIFF
--- a/lib/diode_client/anvil/helper.ex
+++ b/lib/diode_client/anvil/helper.ex
@@ -241,11 +241,11 @@ defmodule DiodeClient.Anvil.Helper do
         # IO.puts(new_data)
         data = data <> new_data
 
-        if creator != nil and String.contains?(data, "Listening on") do
+        if String.contains?(data, "Listening on") do
           send(creator, {self(), :started, port})
           await_exit_status(creator, port, new_data)
         else
-          await_exit_status(creator, port, data <> new_data)
+          await_exit_status(creator, port, data)
         end
 
       {^port, {:exit_status, 0}} ->

--- a/lib/mix/tasks/diode/resolve.ex
+++ b/lib/mix/tasks/diode/resolve.ex
@@ -77,9 +77,7 @@ defmodule Mix.Tasks.Diode.Resolve do
     owner = Contracts.BNS.resolve_name_owner(name)
     puts(level, "BNS owner", Base16.encode(owner))
 
-    if owner != nil do
-      resolve(Base16.encode(owner), level + 1)
-    end
+    resolve(Base16.encode(owner), level + 1)
 
     {name,
      for {name, index} <- Enum.with_index(names) do


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CI has been failing on `mix lint` because Dialyzer on the latest OTP/Elixir versions (currently OTP 29 / Elixir 1.20) reports `:exact_compare` legacy warnings for redundant nil checks.

## Changes

- **`lib/diode_client/anvil/helper.ex`**: Remove `creator != nil` guard — `creator` is always `self()` (a pid). Also fix the log buffer recursion to pass accumulated `data` in the else branch instead of appending `new_data` twice.
- **`lib/mix/tasks/diode/resolve.ex`**: Remove `owner != nil` guard — `resolve_name_owner/1` return type excludes nil.

These fixes mirror the approach from the previously successful branch `fix/anvil-await-exit-unrelated`, which had not been merged to `master` before PR #7 reintroduced the `creator != nil` check.

## Testing

- `mix lint` passes locally (compile, format, credo, dialyzer)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ba15a47-a009-412a-9f3e-702abb736032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ba15a47-a009-412a-9f3e-702abb736032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

