### PR TITLE
Split chain peak consensus from traffic routing

### DIFF
--- a/docs/plan/manager-peak-traffic-split.md
+++ b/docs/plan/manager-peak-traffic-split.md
@@ -1,0 +1,250 @@
+# Plan: Split Chain Peak Consensus from Traffic Routing in `DiodeClient.Manager`
+
+**Status:** Implemented (2026-06-18)  
+**Owner package:** `diode_client_ex` (`lib/diode_client/manager.ex` and new helpers)  
+**Out of scope (v1):** Go `diode_client/rpc/client_manager.go` (latency-only; no multi-chain peak logic)
+
+---
+
+## 1. Overview
+
+`DiodeClient.Manager` currently uses a single `best` connection list for two unrelated jobs:
+
+1. **Chain peak reporting** — what block height/hash each shell (Diode, Moonbeam, Oasis, …) is considered to be at.
+2. **Traffic routing** — which relay to use for port open/listen, `getobject`, default RPC, sticky transaction send, and ticket hints.
+
+Those jobs are coupled today: reported peaks are capped to the **minimum** block among latency-selected `best` nodes, and the **connected** quorum for peak math requires a node to be current on **every** subscribed shell. That design is conservative for security but fails under real fleet conditions (Moonbeam nodes tens of thousands of blocks behind while Diode is current; minority of nodes at the true head).
+
+This plan separates **per-chain peak consensus** from **latency-based traffic best**, keeps the public API stable where possible, and documents behavioral changes.
+
+### Integration context
+
+| Module | Role today | After change |
+|--------|------------|--------------|
+| `DiodeClient.Manager` | Combined peak + best | Orchestrator; delegates to chain + traffic subsystems |
+| `DiodeClient.Connection` | Reports per-shell peaks via `update_info` | Unchanged input; triggers chain peak recompute |
+| `DiodeClient.Shell.Common` | `peak/0` → `Manager.get_peak/1` | Same API; higher/fresher peaks possible |
+| `DiodeClient.Shell` | `rpc/1` → `default_conn/0` | Diode shell unchanged; Moonbeam/Oasis use `get_chain_connection/1` (8.7) |
+| `DiodeClient` | `default_conn/0` → `get_connection/0` | Traffic path only |
+| `Connection` (tickets) | `get_connection?/0` for preferred server IDs | Traffic path only |
+
+---
+
+## 2. Problem statement (evidence)
+
+Live dDrive RPC (2026-06-18) showed:
+
+- ~37 authenticated relay connections.
+- Moonbeam heights bimodal: ~23 nodes at ~16081486+, ~11 nodes **~38,000 blocks behind** (while Diode shell still current on those nodes).
+- Reported Moonbeam peak lagged true max when only a **minority** of nodes were 1 block ahead of the majority (percentile trim + `min(best)` cap).
+
+Root causes in current code:
+
+1. **Global `connected/1`** — node must be ≥ reported peak on **all** shells to participate in peak math for **any** shell.
+2. **`physical_peak_for_shell/7`** — uses `(len - drop)`-th highest block (≈80th percentile), not supermajority at the top height.
+3. **`reported_peaks`** — `min(peaks among best PIDs)` ties peak to latency winners.
+4. **Single `best` list** — used for both `get_connection/0` and peak gating.
+
+---
+
+## 3. Design principles
+
+1. **Per-chain independence.** Peak consensus for shell `S` MUST only consider nodes’ peaks for `S` (plus global auth/liveness rules). Staleness on Moonbeam MUST NOT disqualify a node from Diode peak math.
+
+2. **Peaks follow consensus, not latency.** `get_peak/1` MUST reflect a quorum of nodes at the leading edge for that chain, not the fastest relay.
+
+3. **Traffic follows latency, not peak.** `get_connection/0`, sticky conn, port traffic, and object fetch defaults MUST optimize for RTT and stability, not chain head.
+
+4. **Monotonic peaks.** `chain_peaks[shell]` MUST NOT decrease except on explicit reset (seed list change, offline, manual recovery).
+
+5. **Backward-compatible API.** Function names `get_peak/1`, `get_connection/0`, `subscribe_peak/1` stay; document semantic change (peak may exceed any single traffic relay’s reported block).
+
+6. **Testable pure core.** Consensus math lives in a pure module (`Manager.ChainPeaks`) with table-driven tests including live-derived scenarios.
+
+---
+
+## 4. Target architecture
+
+```
+Connection {:peak, shell, block}
+        │
+        ▼
+Manager.handle_cast {:update_info, ...}
+        │
+        ├──► update_chain_peaks/1     (per shell, supermajority)
+        │         └── chain_peaks, peak subscribers, waiting_for_peak
+        │
+        └──► update_traffic_best/1    (latency, auth only)
+                  └── traffic_best, waiting_traffic, sticky
+```
+
+### 4.1 State rename / split
+
+| Current field | New field | Purpose |
+|---------------|-----------|---------|
+| `best` | `traffic_best` | Low-latency relay PIDs for traffic |
+| `best_timestamp` | `traffic_best_timestamp` | Sticky recompute throttle for traffic |
+| `physical_peaks` | _(removed)_ | Replaced by `chain_peaks` |
+| `peaks` | `chain_peaks` | Authoritative per-shell peak returned by `get_peak/1` |
+| `waiting` | `waiting_traffic` | Blocked `get_connection` callers |
+
+Remove: computing `chain_peaks` from `traffic_best`.
+
+### 4.2 New module: `DiodeClient.Manager.ChainPeaks`
+
+Pure functions (no GenServer):
+
+- `connected_for_shell(shell, conns, chain_peaks, opts)`
+- `consensus_peak_for_shell(shell, connected_infos, last_peak, opts)`
+- `notify_if_changed(old, new)`
+
+Configurable via opts (resolved in §8): supermajority threshold, stale outlier distance, uncle handling.
+
+### 4.3 Traffic subsystem
+
+`update_traffic_best/2`:
+
+- Candidates: authenticated connections (`server_address != nil`) passing **traffic viability** (§8.5).
+- Sort by latency; keep existing `2 * fastest_latency` cluster filter.
+- Keep 30s sticky recompute when still viable.
+
+**Traffic viability (8.5):** A relay is eligible for `traffic_best` only if:
+
+1. `block_number(conn.peaks[DiodeClient.Shell]) >= block_number(chain_peaks[DiodeClient.Shell])`
+2. `Block.epoch(conn.peaks[ticket_shell]) >= Block.epoch(chain_peaks[ticket_shell])` where `ticket_shell` is `DiodeClient.Shell.Moonbeam` today (default on `Connection` init)
+
+Moonbeam/Oasis **block height** staleness does not exclude a relay from traffic if epoch is current. Gross epoch lag excludes the relay from port/ticket paths.
+
+### 4.4 Public API semantics (unchanged names)
+
+| Function | Semantics after change |
+|----------|------------------------|
+| `get_peak(shell)` | `chain_peaks[shell]` from consensus |
+| `get_connection/0` | Random PID from `traffic_best` |
+| `get_sticky_connection/0` | Lowest-latency seed from `traffic_best` (sticky register unchanged) |
+| `subscribe_peak(shell)` | Message on `chain_peaks` change only |
+
+**Removed invariant:** “peak never higher than any `get_connection` relay’s reported peak.”
+
+---
+
+## 5. Consensus algorithm (proposed default)
+
+> **Subject to §8 decisions.** This is the recommended default.
+
+For each subscribed `shell`:
+
+1. Let `C` = `connected_for_shell(shell)` — nodes with `block_number(conn.peaks[shell]) >= block_number(chain_peaks[shell])` and `server_address != nil`.
+2. If `|C| < min_connections()` → no update; `get_peak` may block (unchanged).
+3. Let `max` = highest block number in `C`.
+4. **Outlier trim (gross stale only):** drop nodes where `max - block_number < -stale_threshold(shell)` from consensus set `C'`. Default `stale_threshold`: shell-specific (e.g. 128 blocks Moonbeam, 64 Diode) — not the current bottom-20% percentile.
+5. At height `h` from `max` downward, find block hashes with count ≥ `supermajority(|C'|)`.
+6. Pick highest `h` with a winning hash; ties at same height use existing plurality / uncle hold logic.
+7. Advance `chain_peaks[shell]` only if `h > old_h` and agreement ≥ threshold.
+
+---
+
+## 6. Implementation phases
+
+### Phase 1 — Decouple + per-shell connected (low risk, high value)
+
+- [x] Introduce `connected_for_shell/2`; stop using global `connected/1` in peak path.
+- [x] Set `chain_peaks[shell]` from `Manager.ChainPeaks` consensus per shell.
+- [x] Remove `min(best)` reported peak cap.
+- [x] Add `get_chain_connection/1`; route Moonbeam/Oasis `Shell.rpc` through it (8.7).
+- [x] Update tests; fix docstrings.
+
+**Exit criteria:** Moonbeam staleness no longer poisons Diode peak; peaks no longer capped by fastest nodes.
+
+### Phase 2 — Supermajority consensus
+
+- [x] Extract `Manager.ChainPeaks` with new algorithm (§5).
+- [x] Replace percentile `drop` logic.
+- [x] Add regression tests from live histogram scenarios.
+
+**Exit criteria:** Minority at `H+1` with majority at `H` resolves to `H+1` when ≥ supermajority at `H+1`.
+
+### Phase 3 — Traffic rename + decouple
+
+- [x] Rename `best` → `traffic_best` internally; keep `get_connection` behavior.
+- [x] Separate debounce/sticky timers if needed.
+- [x] Update `manager_best_change_test.exs` → traffic-focused tests.
+
+### Phase 4 — Optional extensions (v2)
+
+- [ ] Failover on known Moonbeam RPC errors across `get_chain_connection` pool
+- [ ] Configurable `ticket_shell` per fleet / connection
+
+---
+
+## 7. Testing
+
+### Unit tests (`test/manager_chain_peaks_test.exs`)
+
+| Scenario | Expected `chain_peaks` |
+|----------|------------------------|
+| 20 @ H+1, 3 @ H | H+1 (majority) |
+| 8 @ H+1, 15 @ H | **§8.1 decides** |
+| 11 nodes 38k behind, 23 current | Current max (outliers trimmed) |
+| Node stale Moonbeam only | Excluded from Moonbeam quorum; still in Diode quorum |
+| Uncle hashes at same height | Hold / plurality per §8.3 |
+| \|C\| < min_connections | No change; waiters block |
+
+### Integration tests
+
+- Update `manager_test.exs`: remove old peak≤conn invariant; add per-shell tests.
+- Keep `manager_best_change_test.exs` for traffic sticky behavior.
+
+### Manual verification
+
+- `~/dDrive/dDrive rpc` histogram script (document in `notes.exs` or mix task).
+- Confirm `get_peak(Moonbeam)` tracks fleet max when supermajority agrees.
+
+---
+
+## 8. Open product decisions
+
+Each item needs owner sign-off before Phase 2+.
+
+| ID | Decision | Recommendation | Chosen |
+|----|----------|----------------|--------|
+| **8.1** | Supermajority threshold | **Strict majority:** `floor(n/2) + 1` | **✓ Strict majority** (2026-06-18) |
+| **8.2** | Minority ahead (e.g. 8 @ H+1, 15 @ H) | **Promote to H+1 only if count ≥ majority threshold; else stay at H** | **✓ Wait for majority** (2026-06-18) |
+| **8.3** | Uncle / hash split at same height | **Keep current plurality; equal split → hold peak** | **✓ Plurality + hold on tie** (2026-06-18) |
+| **8.4** | Traffic candidate gate | **Auth only** — no shell peak requirement | **✓ Auth only** (2026-06-18) |
+| **8.5** | Ticket / port traffic gate | **Diode:** `block ≥ chain_peaks[Diode]`. **Ticket shell (Moonbeam):** `epoch(conn_peak) ≥ epoch(chain_peaks[Moonbeam])` | **✓ Diode block + ticket-shell epoch** (2026-06-18) |
+| **8.6** | Gross stale threshold | **Per-shell config:** Moonbeam 128 blocks, Diode 64, default 64 | **✓ Per-shell defaults** (2026-06-18) |
+| **8.7** | Phase 4 per-shell RPC routing | **Phase 1:** Moonbeam + Oasis (non-Diode shells) use `get_chain_connection(shell)`; Diode keeps `default_conn` | **✓ Moonbeam/Oasis in v1** (2026-06-18) |
+| **8.8** | Backward compatibility / release | **Minor behavior change** in changelog; no API break | **✓ Minor + changelog** (2026-06-18) |
+| **8.9** | `physical_peaks` vs `chain_peaks` | **Merge to `chain_peaks` only** unless debugging needs both | **✓ Single `chain_peaks`** (2026-06-18) |
+
+### Resolved summary
+
+| Area | Decision |
+|------|----------|
+| Consensus | Strict majority (`floor(n/2)+1`) per shell; wait for majority before advancing to H+1 |
+| Uncles | Plurality at height; hold on tie |
+| Traffic pool | Auth + Diode block gate + ticket-shell epoch gate (Moonbeam) |
+| Stale trim | Moonbeam 128 blocks, Diode 64, default 64 |
+| RPC routing | Moonbeam/Oasis → `get_chain_connection/1` in Phase 1; Diode → `default_conn` |
+| Release | Minor version + changelog |
+| State | `chain_peaks` only; `best` → `traffic_best` |
+
+---
+
+## 9. Risks and mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Higher reported peak than any traffic relay has seen | Document; v2 `get_chain_connection` for RPC |
+| Flash majority on wrong fork | Hash agreement required; monotonic advance |
+| More frequent peak updates | Existing 5s debounce on Manager update |
+| Split-brain across clients | Out of scope; same as today |
+
+---
+
+## 10. Version history
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-06-18 | Dominic | All §8 product decisions resolved via review |

--- a/lib/diode_client/manager.ex
+++ b/lib/diode_client/manager.ex
@@ -703,14 +703,13 @@ defmodule DiodeClient.Manager do
         is_nil(diode_peak) or block_number(diode_block) >= block_number(diode_peak)
 
       ticket_ok =
-        is_nil(ticket_peak) or ticket_block == nil or
-          ticket_epoch(ticket_block) >= ticket_epoch(ticket_peak)
+        is_nil(ticket_peak) or
+          (ticket_block != nil and
+             ticket_epoch(ticket_block) >= ticket_epoch(ticket_peak))
 
       diode_ok and ticket_ok
     end
   end
-
-  defp ticket_epoch(nil), do: 0
 
   defp ticket_epoch(block) do
     if Block.diode?(block) do
@@ -730,13 +729,8 @@ defmodule DiodeClient.Manager do
     |> Map.new()
   end
 
-  defp chain_connection_pids(%Manager{} = state, shell) do
-    peak_num = block_number(Map.get(state.chain_peaks, shell))
-
+  defp chain_connection_pids(state = %Manager{}, shell) do
     ChainPeaks.connected_for_shell(shell, state.conns, state.chain_peaks, min_connections())
-    |> Enum.filter(fn {_pid, %Info{peaks: peaks}} ->
-      block_number(Map.get(peaks, shell)) >= peak_num
-    end)
     |> Enum.sort_by(fn {_pid, %Info{latency: latency}} -> latency end)
     |> Enum.map(fn {pid, _} -> pid end)
   end

--- a/lib/diode_client/manager.ex
+++ b/lib/diode_client/manager.ex
@@ -1,21 +1,31 @@
 defmodule DiodeClient.Manager do
   @moduledoc false
-  alias DiodeClient.{Connection, Manager, Manager.LocalPeakPoller, NodeScorer, Rlpx}
+  alias DiodeClient.{
+    Block,
+    Connection,
+    Manager,
+    Manager.ChainPeaks,
+    Manager.LocalPeakPoller,
+    NodeScorer,
+    Rlpx
+  }
+
   use GenServer
   require Logger
+
+  @ticket_shell DiodeClient.Shell.Moonbeam
 
   defstruct [
     :conns,
     :server_list,
-    :waiting,
+    :waiting_traffic,
     :waiting_for_peak,
-    :best,
-    :physical_peaks,
-    :peaks,
+    :traffic_best,
+    :chain_peaks,
     :online,
     :shells,
     :sticky,
-    :best_timestamp,
+    :traffic_best_timestamp,
     :debounce_timeout,
     :peak_subscribers,
     :peak_subscriber_refs,
@@ -59,13 +69,12 @@ defmodule DiodeClient.Manager do
     state = %Manager{
       conns: %{},
       online: true,
-      physical_peaks: %{},
-      peaks: %{},
+      chain_peaks: %{},
       server_list: seed_list(),
       shells: MapSet.new(default_shells()),
-      waiting: [],
+      waiting_traffic: [],
       waiting_for_peak: %{},
-      best: [],
+      traffic_best: [],
       debounce_timeout: @initial_debounce_timeout,
       peak_subscribers: %{},
       peak_subscriber_refs: %{},
@@ -183,8 +192,7 @@ defmodule DiodeClient.Manager do
   end
 
   @doc """
-    get_connection and get_peak are linked in that peak will never return a block
-    higher than any of the connections returned by get_connection has reported.
+  Returns a low-latency relay for Diode traffic (ports, objects, default RPC).
   """
   def get_connection() do
     GenServer.call(__MODULE__, :get_connection, :infinity)
@@ -222,8 +230,7 @@ defmodule DiodeClient.Manager do
   end
 
   @doc """
-    get_connection and get_peak are linked in that peak will never return a block
-    higher than any of the connections returned by get_connection has reported.
+  Returns the consensus chain peak for `shell` from per-chain supermajority.
   """
   def get_peak(shell) when is_atom(shell) do
     # sanity check that the shell is valid
@@ -248,6 +255,20 @@ defmodule DiodeClient.Manager do
   def unsubscribe_peak(shell) when is_atom(shell) do
     _chain_id = shell.chain_id()
     GenServer.call(__MODULE__, {:unsubscribe_peak, shell}, :infinity)
+  end
+
+  @doc """
+  Returns a relay at the consensus peak for `shell`, preferring low latency.
+  Falls back to `get_connection/0` when no qualifying relay exists.
+  """
+  def get_chain_connection(shell) when is_atom(shell) do
+    _chain_id = shell.chain_id()
+
+    case GenServer.call(__MODULE__, {:get_chain_connection, shell}, :infinity) do
+      pid when is_pid(pid) -> pid
+      [] -> get_connection()
+      pids when is_list(pids) -> Enum.random(pids)
+    end
   end
 
   def connections() do
@@ -390,12 +411,11 @@ defmodule DiodeClient.Manager do
     {:noreply, do_set_online(state, new_online)}
   end
 
-  def handle_cast({:local_peak, shell, block}, state = %Manager{peaks: peaks}) do
-    old_peaks = peaks
-    reported_peaks = %{shell => block}
-    notify_peak_subscribers(state.peak_subscribers, old_peaks, reported_peaks)
+  def handle_cast({:local_peak, shell, block}, state = %Manager{chain_peaks: chain_peaks}) do
+    old_peaks = chain_peaks
+    new_peaks = %{shell => block}
+    notify_peak_subscribers(state.peak_subscribers, old_peaks, new_peaks)
 
-    # Reply to any get_peak waiters
     waiting_for_peak =
       case Map.pop(state.waiting_for_peak, shell) do
         {nil, rest} ->
@@ -408,8 +428,7 @@ defmodule DiodeClient.Manager do
 
     state =
       state
-      |> Map.put(:peaks, Map.put(peaks, shell, block))
-      |> Map.put(:physical_peaks, Map.put(state.physical_peaks, shell, block))
+      |> Map.put(:chain_peaks, Map.put(chain_peaks, shell, block))
       |> Map.put(:waiting_for_peak, waiting_for_peak)
 
     {:noreply, state}
@@ -417,7 +436,7 @@ defmodule DiodeClient.Manager do
 
   @impl true
   def handle_cast({:set_connection, cpid}, state = %Manager{conns: _conns}) do
-    {:noreply, %{state | best: [cpid]}}
+    {:noreply, %{state | traffic_best: [cpid]}}
   end
 
   def handle_cast({:update_info, cpid, info}, state = %Manager{conns: conns}) do
@@ -462,13 +481,13 @@ defmodule DiodeClient.Manager do
     state
   end
 
-  defp do_restart_conn(info, state = %Manager{peaks: peaks, conns: conns}) do
+  defp do_restart_conn(info, state = %Manager{chain_peaks: chain_peaks, conns: conns}) do
     pid =
       case Connection.start_link(info.server_url, info.ports) do
         {:ok, pid} ->
           Process.monitor(pid)
 
-          for {shell, _} <- peaks do
+          for {shell, _} <- chain_peaks do
             safe_send(pid, {:subscribe, shell})
           end
 
@@ -484,7 +503,7 @@ defmodule DiodeClient.Manager do
 
   @impl true
   def handle_call(:online?, _from, state = %Manager{online: online}) do
-    {:reply, online and map_size(connected(state)) > 0, state}
+    {:reply, online and any_authenticated?(state), state}
   end
 
   def handle_call({:set_online, new_online}, _from, state) do
@@ -498,24 +517,19 @@ defmodule DiodeClient.Manager do
   def handle_call(
         {:get_peak, shell},
         from,
-        state = %Manager{peaks: peaks, conns: conns, shells: shells}
+        state = %Manager{chain_peaks: chain_peaks, conns: conns, shells: shells}
       ) do
-    # Local shells (e.g. Anvil) use HTTP/WS; fetch peak directly when not in state
-    if local_shell?(shell) and Map.get(peaks, shell) == nil do
+    if local_shell?(shell) and Map.get(chain_peaks, shell) == nil do
       peak = shell.peak()
 
-      state = %{
-        state
-        | peaks: Map.put(peaks, shell, peak),
-          physical_peaks: Map.put(state.physical_peaks, shell, peak)
-      }
+      state = %{state | chain_peaks: Map.put(chain_peaks, shell, peak)}
 
       {:reply, peak, state}
     else
       state = %{state | shells: MapSet.put(shells, shell)}
       for c <- Map.keys(conns), do: safe_send(c, {:subscribe, shell})
 
-      if peak = Map.get(peaks, shell) do
+      if peak = Map.get(chain_peaks, shell) do
         {:reply, peak, state}
       else
         waiting_for_peak = Map.get(state.waiting_for_peak, shell, []) ++ [from]
@@ -569,26 +583,38 @@ defmodule DiodeClient.Manager do
     end
   end
 
-  def handle_call(:get_connection?, _from, state = %Manager{online: online, best: best}) do
+  def handle_call(:get_connection?, _from, state = %Manager{online: online, traffic_best: best}) do
     {:reply, if(online, do: best, else: []), state}
   end
 
-  def handle_call(:get_connection, from, state = %Manager{online: false, waiting: waiting}) do
-    {:noreply, %Manager{state | waiting: waiting ++ [from]}}
+  def handle_call(
+        :get_connection,
+        from,
+        state = %Manager{online: false, waiting_traffic: waiting}
+      ) do
+    {:noreply, %Manager{state | waiting_traffic: waiting ++ [from]}}
   end
 
-  def handle_call(:get_connection, from, state = %Manager{best: [], waiting: waiting}) do
-    {:noreply, %Manager{state | waiting: waiting ++ [from]}}
+  def handle_call(
+        :get_connection,
+        from,
+        state = %Manager{traffic_best: [], waiting_traffic: waiting}
+      ) do
+    {:noreply, %Manager{state | waiting_traffic: waiting ++ [from]}}
   end
 
-  def handle_call(:get_connection, _from, state = %Manager{best: best}) do
+  def handle_call(:get_connection, _from, state = %Manager{traffic_best: best}) do
     {:reply, best, state}
+  end
+
+  def handle_call({:get_chain_connection, shell}, _from, state) do
+    {:reply, chain_connection_pids(state, shell), state}
   end
 
   def handle_call(
         :get_sticky_connection?,
         _from,
-        state = %Manager{sticky: sticky, online: online, best: best, conns: conns}
+        state = %Manager{sticky: sticky, online: online, traffic_best: best, conns: conns}
       ) do
     pid = Process.whereis(__MODULE__.Sticky)
 
@@ -604,7 +630,7 @@ defmodule DiodeClient.Manager do
         {:reply, nil, state}
 
       true ->
-        connected(state)
+        traffic_viable_conns(state)
         |> Enum.filter(fn {_, %Info{type: type}} -> type == :seed end)
         |> Enum.sort_by(fn {_, %Info{latency: latency}} -> latency end)
         |> List.first()
@@ -632,9 +658,8 @@ defmodule DiodeClient.Manager do
        state
        | server_list: list,
          sticky: nil,
-         best: [],
-         peaks: %{},
-         physical_peaks: %{}
+         traffic_best: [],
+         chain_peaks: %{}
      })}
   end
 
@@ -655,27 +680,65 @@ defmodule DiodeClient.Manager do
     end
   end
 
-  defp connected(%Manager{conns: conns, shells: shells, peaks: peaks}) do
-    connected =
-      Enum.filter(conns, fn {_, %Info{server_address: addr, peaks: conn_peaks}} ->
-        addr != nil and
-          Enum.all?(shells, fn shell ->
-            block_number(conn_peaks[shell]) >= block_number(peaks[shell])
-          end)
-      end)
-      |> Map.new()
-
-    # Reject single node connections
-    if map_size(connected) < min_connections() do
-      %{}
-    else
-      connected
-    end
+  defp any_authenticated?(%Manager{conns: conns}) do
+    Enum.any?(conns, fn {_pid, %Info{server_address: addr}} -> addr != nil end)
   end
 
   defp min_connections() do
-    # When the node list is force set by the user we ignore the usual minimum requirement.
     min(3, map_size(seed_list()))
+  end
+
+  defp traffic_viable?(%Info{server_address: addr, peaks: conn_peaks}, %Manager{
+         chain_peaks: chain_peaks
+       }) do
+    if addr == nil do
+      false
+    else
+      diode_peak = Map.get(chain_peaks, DiodeClient.Shell)
+      ticket_peak = Map.get(chain_peaks, @ticket_shell)
+      diode_block = Map.get(conn_peaks, DiodeClient.Shell)
+      ticket_block = Map.get(conn_peaks, @ticket_shell)
+
+      diode_ok =
+        is_nil(diode_peak) or block_number(diode_block) >= block_number(diode_peak)
+
+      ticket_ok =
+        is_nil(ticket_peak) or ticket_block == nil or
+          ticket_epoch(ticket_block) >= ticket_epoch(ticket_peak)
+
+      diode_ok and ticket_ok
+    end
+  end
+
+  defp ticket_epoch(nil), do: 0
+
+  defp ticket_epoch(block) do
+    if Block.diode?(block) do
+      Block.epoch(block)
+    else
+      case Map.get(block, "timestamp") do
+        nil -> 0
+        "" -> 0
+        _ -> Block.epoch(block)
+      end
+    end
+  end
+
+  defp traffic_viable_conns(state = %Manager{conns: conns}) do
+    conns
+    |> Enum.filter(fn {_pid, info} -> traffic_viable?(info, state) end)
+    |> Map.new()
+  end
+
+  defp chain_connection_pids(%Manager{} = state, shell) do
+    peak_num = block_number(Map.get(state.chain_peaks, shell))
+
+    ChainPeaks.connected_for_shell(shell, state.conns, state.chain_peaks, min_connections())
+    |> Enum.filter(fn {_pid, %Info{peaks: peaks}} ->
+      block_number(Map.get(peaks, shell)) >= peak_num
+    end)
+    |> Enum.sort_by(fn {_pid, %Info{latency: latency}} -> latency end)
+    |> Enum.map(fn {pid, _} -> pid end)
   end
 
   defp schedule_update(state) do
@@ -691,170 +754,58 @@ defmodule DiodeClient.Manager do
   end
 
   defp update(state) do
-    state = update_peaks(state)
-    connected_list = Map.values(connected(state))
-    viable_best = Enum.filter(state.best, &best_pid_viable?(state, &1))
+    state = update_chain_peaks(state)
+    traffic_candidates = Map.values(traffic_viable_conns(state))
+    viable_best = Enum.filter(state.traffic_best, &traffic_best_pid_viable?(state, &1))
 
     if viable_best == [] or
-         System.os_time(:second) - state.best_timestamp > 30 do
-      update_best(state, connected_list)
+         System.os_time(:second) - state.traffic_best_timestamp > 30 do
+      update_traffic_best(state, traffic_candidates)
     else
-      %{state | best: viable_best}
+      %{state | traffic_best: viable_best}
     end
   end
 
-  # Best PID is still usable: live connection, authenticated, peaks at least reported.
-  defp best_pid_viable?(%Manager{conns: conns, shells: shells, peaks: reported}, pid) do
+  defp traffic_best_pid_viable?(state = %Manager{conns: conns}, pid) do
     case Map.get(conns, pid) do
-      %Info{server_address: addr, peaks: conn_peaks} when addr != nil ->
-        Enum.all?(shells, fn shell ->
-          block_number(Map.get(conn_peaks, shell)) >= block_number(Map.get(reported, shell))
-        end)
-
-      _ ->
-        false
+      %Info{} = info -> traffic_viable?(info, state)
+      _ -> false
     end
   end
 
-  defp physical_peak_for_shell(
-         shell,
-         connected,
-         len,
-         drop,
-         min_agreement,
-         last_peaks,
-         last_reported_uncle_block
-       ) do
-    blocks = Enum.map(connected, fn %Info{peaks: peaks} -> peaks[shell] end)
-    # Precompute block_number once per block to avoid hundreds of Rlpx.bin2uint calls
-    blocks_with_num = Enum.map(blocks, fn b -> {b, block_number(b)} end)
-
-    take_count = max(1, len - drop)
-
-    peak_num =
-      blocks_with_num
-      |> Enum.map(&elem(&1, 1))
-      |> Enum.sort(:desc)
-      |> Enum.at(take_count - 1)
-
-    blocks_at_peak =
-      if peak_num != nil do
-        Enum.filter(blocks_with_num, fn {_, n} -> n == peak_num end)
-        |> Enum.map(&elem(&1, 0))
-      else
-        []
-      end
-
-    # Cache block_hash per unique block to avoid repeated Base16.encode
-    hash_cache = Map.new(Enum.uniq(blocks_at_peak), fn b -> {b, block_hash(b)} end)
-
-    candidates =
-      Enum.group_by(blocks_at_peak, fn block -> Map.fetch!(hash_cache, block) end)
-
-    last_reported_uncle_block =
-      if map_size(candidates) > 1 and Map.get(last_reported_uncle_block, shell) != peak_num do
-        Logger.debug(
-          "Multiple uncle blocks with the same block_number=#{peak_num} found for shell #{shell}"
-        )
-
-        Map.put(last_reported_uncle_block, shell, peak_num)
-      else
-        last_reported_uncle_block
-      end
-
-    result = resolve_peak_from_candidates(candidates)
-    last_peak_num = block_number(last_peaks[shell])
-    peak_num = peak_num || 0
-
-    peak =
-      cond do
-        result == nil ->
-          last_peaks[shell]
-
-        peak_num <= 0 ->
-          last_peaks[shell]
-
-        length(elem(result, 0)) >= min_agreement and peak_num > last_peak_num ->
-          elem(result, 1)
-
-        true ->
-          last_peaks[shell]
-      end
-
-    {{shell, peak}, last_reported_uncle_block}
-  end
-
-  defp resolve_peak_from_candidates(candidates) do
-    case Enum.sort_by(candidates, fn {_hash, blocks} -> length(blocks) end, :desc) do
-      [{_hash, agreement = [block | _]}] ->
-        {agreement, block}
-
-      [{_hash, agreement = [block | _]}, {_challenger_hash, challenger} | _rest] ->
-        if length(agreement) > length(challenger) do
-          {agreement, block}
-        else
-          nil
-        end
-
-      _ ->
-        nil
-    end
-  end
-
-  defp update_peaks(
+  defp update_chain_peaks(
          state = %Manager{
-           physical_peaks: last_peaks,
+           chain_peaks: last_peaks,
            shells: shells,
-           last_reported_uncle_block: last_reported_uncle_block
+           last_reported_uncle_block: last_reported_uncle_block,
+           conns: conns
          }
        ) do
-    connected = Map.values(connected(state))
-    len = length(connected)
-    min_agreement = min(2, min_connections())
+    min_conn = min_connections()
+    opts = [min_connections: min_conn]
 
-    drop =
-      if len > 1 do
-        # We remove the bottom 20% (but at least 1) of the connected nodes to avoid stale peaks
-        max(1, div(len, 5))
-      else
-        # If there is only one connected node, we don't remove any
-        0
-      end
-
-    # Get the highest peak for each shell
-    {physical_peaks, last_reported_uncle_block} =
+    {chain_peaks, last_reported_uncle_block} =
       Enum.reduce(shells, {%{}, last_reported_uncle_block}, fn shell, {peaks, reported} ->
-        {{shell, peak}, reported} =
-          physical_peak_for_shell(
+        connected =
+          ChainPeaks.connected_for_shell(shell, conns, last_peaks, min_conn)
+          |> Map.values()
+
+        {peak, reported} =
+          ChainPeaks.consensus_peak_for_shell(
             shell,
             connected,
-            len,
-            drop,
-            min_agreement,
-            last_peaks,
-            reported
+            Map.get(last_peaks, shell),
+            reported,
+            opts
           )
 
         {Map.put(peaks, shell, peak), reported}
       end)
 
-    best_peaks =
-      state.best
-      |> Enum.filter(&Map.has_key?(state.conns, &1))
-      |> Enum.map(fn pid -> Map.get(state.conns[pid], :peaks) end)
-
-    reported_peaks =
-      for {shell, _peak} <- physical_peaks do
-        best_shell_peaks = Enum.map(best_peaks, fn peaks -> peaks[shell] end)
-        min_peak = Enum.min_by(best_shell_peaks, fn peak -> block_number(peak) end, fn -> nil end)
-        {shell, min_peak}
-      end
-      |> Map.new()
-
     debounce_timeout =
       if state.debounce_timeout == @initial_debounce_timeout and
-           state.best != [] and
-           not Enum.any?(state.peaks, fn {_shell, peak} -> block_number(peak) == 0 end) do
+           state.traffic_best != [] and
+           not Enum.any?(state.chain_peaks, fn {_shell, peak} -> block_number(peak) == 0 end) do
         5_000
       else
         state.debounce_timeout
@@ -862,7 +813,7 @@ defmodule DiodeClient.Manager do
 
     waiting_for_peak =
       Enum.filter(state.waiting_for_peak, fn {shell, pids} ->
-        if peak = reported_peaks[shell] do
+        if peak = chain_peaks[shell] do
           for pid <- pids, do: GenServer.reply(pid, peak)
           false
         else
@@ -871,12 +822,11 @@ defmodule DiodeClient.Manager do
       end)
       |> Map.new()
 
-    notify_peak_subscribers(state.peak_subscribers, state.peaks, reported_peaks)
+    notify_peak_subscribers(state.peak_subscribers, state.chain_peaks, chain_peaks)
 
     %Manager{
       state
-      | physical_peaks: physical_peaks,
-        peaks: reported_peaks,
+      | chain_peaks: chain_peaks,
         waiting_for_peak: waiting_for_peak,
         debounce_timeout: debounce_timeout,
         last_reported_uncle_block: last_reported_uncle_block
@@ -897,19 +847,12 @@ defmodule DiodeClient.Manager do
     :ok
   end
 
-  defp update_best(
-         state = %Manager{waiting: waiting, best: prev_best, peaks: reported_peaks},
-         connected_list
+  defp update_traffic_best(
+         state = %Manager{waiting_traffic: waiting, traffic_best: prev_best},
+         traffic_candidates
        ) do
     new_best =
-      connected_list
-      # Use reported peaks (same threshold as connected/1), not physical_peaks.
-      |> Enum.filter(fn %Info{peaks: conn_peaks} ->
-        Enum.all?(reported_peaks, fn {shell, peak} ->
-          block_number(peak) <= block_number(Map.get(conn_peaks, shell))
-        end)
-      end)
-      # Sort by latency
+      traffic_candidates
       |> Enum.sort_by(fn %Info{latency: latency} -> latency end)
 
     if peak = List.first(new_best) do
@@ -924,29 +867,26 @@ defmodule DiodeClient.Manager do
             "#{url}: #{trunc(latency)}"
           end)
 
-        Logger.debug("Best connection changed to [#{servers}]")
+        Logger.debug("Traffic best connection changed to [#{servers}]")
       end
 
       for from <- waiting, do: GenServer.reply(from, new_best_pids)
 
       %Manager{
         state
-        | best: new_best_pids,
-          waiting: [],
-          best_timestamp: System.os_time(:second)
+        | traffic_best: new_best_pids,
+          waiting_traffic: [],
+          traffic_best_timestamp: System.os_time(:second)
       }
     else
-      # Keep previous best while still viable (e.g. transient < min_connections quorum).
-      best = Enum.filter(prev_best, &best_pid_viable?(state, &1))
+      best = Enum.filter(prev_best, &traffic_best_pid_viable?(state, &1))
 
-      %Manager{state | best: best}
+      %Manager{state | traffic_best: best}
     end
   end
 
   defp block_number(nil), do: 0
   defp block_number(block), do: Rlpx.bin2uint(block["number"])
-  defp block_hash(nil), do: nil
-  defp block_hash(block), do: DiodeClient.Base16.encode(block["block_hash"])
 
   @impl true
   def handle_continue(:init, state) do
@@ -988,7 +928,7 @@ defmodule DiodeClient.Manager do
 
       not new_online ->
         for pid <- pids, do: safe_send(pid, :stop)
-        %{state | server_list: seed_list(), conns: %{}, best: []}
+        %{state | server_list: seed_list(), conns: %{}, traffic_best: []}
     end
   end
 
@@ -1087,34 +1027,41 @@ defmodule DiodeClient.Manager do
   # Test-only helpers for diagnosing "Best connection changed" log behavior.
   @doc false
   def __test_simulate_update__(state) do
-    prev_best = state.best
+    prev_best = state.traffic_best
     prev_urls = __test_best_urls__(state, prev_best)
 
-    state = update_peaks(state)
-    connected_map = connected(state)
-    connected_list = Map.values(connected_map)
-    viable_best = Enum.filter(state.best, &best_pid_viable?(state, &1))
+    state = update_chain_peaks(state)
+    traffic_candidates = Map.values(traffic_viable_conns(state))
+    viable_best = Enum.filter(state.traffic_best, &traffic_best_pid_viable?(state, &1))
 
     recompute_reason =
       cond do
         viable_best == [] -> :best_not_viable
-        System.os_time(:second) - state.best_timestamp > 30 -> :timestamp_expired
+        System.os_time(:second) - state.traffic_best_timestamp > 30 -> :timestamp_expired
         true -> :no_recompute
       end
 
     {state, would_log} =
       case recompute_reason do
         :no_recompute ->
-          {%{state | best: viable_best}, false}
+          {%{state | traffic_best: viable_best}, false}
 
         _ ->
-          prev_for_log = state.best
-          state = update_best(state, connected_list)
-          {state, prev_for_log != state.best}
+          prev_for_log = state.traffic_best
+          state = update_traffic_best(state, traffic_candidates)
+          {state, prev_for_log != state.traffic_best}
       end
 
-    new_best = state.best
+    new_best = state.traffic_best
     new_urls = __test_best_urls__(state, new_best)
+
+    connected_count =
+      state.shells
+      |> Enum.map(fn shell ->
+        ChainPeaks.connected_for_shell(shell, state.conns, state.chain_peaks, min_connections())
+        |> map_size()
+      end)
+      |> Enum.min(fn -> 0 end)
 
     diag = %{
       prev_best: prev_best,
@@ -1125,7 +1072,7 @@ defmodule DiodeClient.Manager do
       pids_changed: prev_best != new_best,
       urls_unchanged_pids_changed: prev_urls == new_urls and prev_best != new_best,
       recompute_reason: recompute_reason,
-      connected_count: map_size(connected_map)
+      connected_count: connected_count
     }
 
     {state, diag}

--- a/lib/diode_client/manager/chain_peaks.ex
+++ b/lib/diode_client/manager/chain_peaks.ex
@@ -76,42 +76,62 @@ defmodule DiodeClient.Manager.ChainPeaks do
         heights = trimmed |> Enum.map(&elem(&1, 1)) |> Enum.uniq() |> Enum.sort(:desc)
 
         {peak, uncle_reported} =
-          Enum.reduce_while(heights, {last_peak, last_reported_uncle_block}, fn height,
-                                                                                {acc, reported} ->
-            blocks_at_height =
-              trimmed
-              |> Enum.filter(fn {_, num} -> num == height end)
-              |> Enum.map(&elem(&1, 0))
-
-            candidates = group_by_hash(blocks_at_height)
-
-            reported =
-              if map_size(candidates) > 1 and Map.get(reported, shell) != height do
-                require Logger
-
-                Logger.debug(
-                  "Multiple uncle blocks with the same block_number=#{height} found for shell #{inspect(shell)}"
-                )
-
-                Map.put(reported, shell, height)
-              else
-                reported
-              end
-
-            case resolve_peak_from_candidates(candidates) do
-              {agreement, block} ->
-                if length(agreement) >= majority and height > last_peak_num do
-                  {:halt, {block, reported}}
-                else
-                  {:cont, {acc, reported}}
-                end
-
-              nil ->
-                {:cont, {acc, reported}}
-            end
+          Enum.reduce_while(heights, {last_peak, last_reported_uncle_block}, fn height, acc ->
+            reduce_height(
+              height,
+              shell,
+              trimmed,
+              majority,
+              last_peak_num,
+              acc
+            )
           end)
 
         {peak, uncle_reported}
+    end
+  end
+
+  defp reduce_height(height, shell, trimmed, majority, last_peak_num, {acc, reported}) do
+    if height <= last_peak_num do
+      {:halt, {acc, reported}}
+    else
+      try_height_consensus(height, shell, trimmed, majority, acc, reported)
+    end
+  end
+
+  defp try_height_consensus(height, shell, trimmed, majority, acc, reported) do
+    blocks_at_height =
+      trimmed
+      |> Enum.filter(fn {_, num} -> num == height end)
+      |> Enum.map(&elem(&1, 0))
+
+    candidates = group_by_hash(blocks_at_height)
+    reported = maybe_log_uncle(shell, height, candidates, reported)
+
+    case resolve_peak_from_candidates(candidates) do
+      {agreement, block} ->
+        if length(agreement) >= majority do
+          {:halt, {block, reported}}
+        else
+          {:cont, {acc, reported}}
+        end
+
+      nil ->
+        {:cont, {acc, reported}}
+    end
+  end
+
+  defp maybe_log_uncle(shell, height, candidates, reported) do
+    if map_size(candidates) > 1 and Map.get(reported, shell) != height do
+      require Logger
+
+      Logger.debug(
+        "Multiple uncle blocks with the same block_number=#{height} found for shell #{inspect(shell)}"
+      )
+
+      Map.put(reported, shell, height)
+    else
+      reported
     end
   end
 

--- a/lib/diode_client/manager/chain_peaks.ex
+++ b/lib/diode_client/manager/chain_peaks.ex
@@ -1,0 +1,150 @@
+defmodule DiodeClient.Manager.ChainPeaks do
+  @moduledoc false
+  alias DiodeClient.{Base16, Manager.Info, Rlpx}
+
+  @default_stale_threshold 64
+  @moonbeam_stale_threshold 128
+  @diode_stale_threshold 64
+
+  @doc """
+  Returns authenticated connections at or above the reported peak for `shell` only.
+  """
+  def connected_for_shell(shell, conns, chain_peaks, min_connections) do
+    reported = block_number(Map.get(chain_peaks, shell))
+
+    connected =
+      conns
+      |> Enum.filter(fn {_pid, %Info{server_address: addr, peaks: conn_peaks}} ->
+        addr != nil and block_number(Map.get(conn_peaks, shell)) >= reported
+      end)
+      |> Map.new()
+
+    if map_size(connected) < min_connections, do: %{}, else: connected
+  end
+
+  @doc """
+  Computes the consensus peak block for one shell using strict majority at the leading height.
+  """
+  def consensus_peak_for_shell(
+        shell,
+        connected_infos,
+        last_peak,
+        last_reported_uncle_block,
+        opts
+      ) do
+    min_connections = Keyword.fetch!(opts, :min_connections)
+    len = length(connected_infos)
+
+    if len < min_connections do
+      {last_peak, last_reported_uncle_block}
+    else
+      do_consensus_peak_for_shell(
+        shell,
+        connected_infos,
+        last_peak,
+        last_reported_uncle_block
+      )
+    end
+  end
+
+  defp do_consensus_peak_for_shell(
+         shell,
+         connected_infos,
+         last_peak,
+         last_reported_uncle_block
+       ) do
+    last_peak_num = block_number(last_peak)
+
+    blocks_with_num =
+      connected_infos
+      |> Enum.map(fn %Info{peaks: peaks} -> Map.get(peaks, shell) end)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.map(fn block -> {block, block_number(block)} end)
+
+    case blocks_with_num do
+      [] ->
+        {last_peak, last_reported_uncle_block}
+
+      _ ->
+        max_num = blocks_with_num |> Enum.map(&elem(&1, 1)) |> Enum.max()
+        threshold = stale_threshold(shell)
+
+        trimmed =
+          Enum.filter(blocks_with_num, fn {_, num} -> max_num - num <= threshold end)
+
+        majority = div(length(trimmed), 2) + 1
+        heights = trimmed |> Enum.map(&elem(&1, 1)) |> Enum.uniq() |> Enum.sort(:desc)
+
+        {peak, uncle_reported} =
+          Enum.reduce_while(heights, {last_peak, last_reported_uncle_block}, fn height,
+                                                                                {acc, reported} ->
+            blocks_at_height =
+              trimmed
+              |> Enum.filter(fn {_, num} -> num == height end)
+              |> Enum.map(&elem(&1, 0))
+
+            candidates = group_by_hash(blocks_at_height)
+
+            reported =
+              if map_size(candidates) > 1 and Map.get(reported, shell) != height do
+                require Logger
+
+                Logger.debug(
+                  "Multiple uncle blocks with the same block_number=#{height} found for shell #{inspect(shell)}"
+                )
+
+                Map.put(reported, shell, height)
+              else
+                reported
+              end
+
+            case resolve_peak_from_candidates(candidates) do
+              {agreement, block} ->
+                if length(agreement) >= majority and height > last_peak_num do
+                  {:halt, {block, reported}}
+                else
+                  {:cont, {acc, reported}}
+                end
+
+              nil ->
+                {:cont, {acc, reported}}
+            end
+          end)
+
+        {peak, uncle_reported}
+    end
+  end
+
+  defp group_by_hash(blocks) do
+    hash_cache = Map.new(Enum.uniq(blocks), fn block -> {block, block_hash(block)} end)
+
+    Enum.group_by(blocks, fn block -> Map.fetch!(hash_cache, block) end)
+  end
+
+  defp resolve_peak_from_candidates(candidates) do
+    case Enum.sort_by(candidates, fn {_hash, blocks} -> length(blocks) end, :desc) do
+      [{_hash, agreement = [block | _]}] ->
+        {agreement, block}
+
+      [{_hash, agreement = [block | _]}, {_challenger_hash, challenger} | _rest] ->
+        if length(agreement) > length(challenger) do
+          {agreement, block}
+        else
+          nil
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  def stale_threshold(DiodeClient.Shell.Moonbeam), do: @moonbeam_stale_threshold
+  def stale_threshold(DiodeClient.Shell), do: @diode_stale_threshold
+  def stale_threshold(_shell), do: @default_stale_threshold
+
+  defp block_number(nil), do: 0
+  defp block_number(block), do: Rlpx.bin2uint(block["number"])
+
+  defp block_hash(nil), do: nil
+  defp block_hash(block), do: Base16.encode(block["block_hash"])
+end

--- a/lib/diode_client/shell.ex
+++ b/lib/diode_client/shell.ex
@@ -312,20 +312,22 @@ defmodule DiodeClient.Shell do
   end
 
   def cached_rpc(args) do
-    ETSLru.fetch(ShellCache, args, fn ->
-      # Single retry for remote_closed
-      c1 = conn()
-      name = Connection.server_url(c1)
+    chain_cached_rpc(__MODULE__, args)
+  end
 
-      case Connection.rpc(conn(), args) do
+  def chain_cached_rpc(shell, args) do
+    ETSLru.fetch(ShellCache, {shell, args}, fn ->
+      conn = chain_conn(shell)
+      name = Connection.server_url(conn)
+
+      case Connection.rpc(conn, args) do
         {:error, "remote_closed"} ->
-          Connection.rpc(conn(), args)
+          Connection.rpc(chain_conn(shell), args)
 
         {:error, other} ->
           {:error, "#{name}: #{inspect(other)}"}
 
         [json] when is_binary(json) ->
-          # This is a moonbeam specific error, that unfortunatelly is common.
           if String.contains?(json, "failed to retrieve Runtime Api version") do
             {:error, "#{name}: failed to retrieve Runtime Api version"}
           else
@@ -339,11 +341,19 @@ defmodule DiodeClient.Shell do
   end
 
   def uncache_rpc(args) do
-    ETSLru.delete(ShellCache, args)
+    ETSLru.delete(ShellCache, {__MODULE__, args})
+  end
+
+  def chain_uncache_rpc(shell, args) do
+    ETSLru.delete(ShellCache, {shell, args})
   end
 
   def rpc(args) do
-    Connection.rpc(conn(), args)
+    chain_rpc(__MODULE__, args)
+  end
+
+  def chain_rpc(shell, args) do
+    Connection.rpc(chain_conn(shell), args)
   end
 
   def ether(x), do: trunc(1000 * finney(1) * x)
@@ -360,6 +370,11 @@ defmodule DiodeClient.Shell do
 
   defp conn() do
     DiodeClient.default_conn()
+  end
+
+  defp chain_conn(shell) do
+    DiodeClient.Manager.await()
+    DiodeClient.Manager.get_chain_connection(shell)
   end
 
   def sticky_conn() do

--- a/lib/diode_client/shell/common.ex
+++ b/lib/diode_client/shell/common.ex
@@ -24,9 +24,9 @@ defmodule DiodeClient.Shell.Common do
       alias DiodeClient.Shell.Common
 
       if __MODULE__ != DiodeClient.Shell and __MODULE__ != DiodeClient.Shell.Anvil do
-        defdelegate cached_rpc(args), to: DiodeClient.Shell
-        defdelegate uncache_rpc(args), to: DiodeClient.Shell
-        defdelegate rpc(args), to: DiodeClient.Shell
+        def rpc(args), do: DiodeClient.Shell.chain_rpc(__MODULE__, args)
+        def cached_rpc(args), do: DiodeClient.Shell.chain_cached_rpc(__MODULE__, args)
+        def uncache_rpc(args), do: DiodeClient.Shell.chain_uncache_rpc(__MODULE__, args)
       end
 
       if __MODULE__ != DiodeClient.Shell.Anvil do

--- a/test/manager_best_change_test.exs
+++ b/test/manager_best_change_test.exs
@@ -20,7 +20,11 @@ defmodule DiodeClient.ManagerBestChangeTest do
   @as1_url "as1.prenet.diode.io"
 
   defp block(n) do
-    %{"number" => Rlpx.uint2bin(n), "block_hash" => :crypto.hash(:sha256, <<n>>)}
+    %{
+      "number" => Rlpx.uint2bin(n),
+      "block_hash" => :crypto.hash(:sha256, <<n>>),
+      "timestamp" => Rlpx.uint2bin(n * 6)
+    }
   end
 
   defp peaks(n), do: Map.new(@shells, fn shell -> {shell, block(n)} end)
@@ -45,14 +49,13 @@ defmodule DiodeClient.ManagerBestChangeTest do
     %Manager{
       conns: conns,
       shells: MapSet.new(@shells),
-      physical_peaks: peaks(height),
-      peaks: peaks(height),
-      best: Keyword.get(opts, :best, []),
-      best_timestamp: Keyword.get(opts, :best_timestamp, System.os_time(:second)),
+      chain_peaks: peaks(height),
+      traffic_best: Keyword.get(opts, :best, []),
+      traffic_best_timestamp: Keyword.get(opts, :best_timestamp, System.os_time(:second)),
       debounce_timeout: 100,
       online: true,
       server_list: %{},
-      waiting: [],
+      waiting_traffic: [],
       waiting_for_peak: %{},
       sticky: nil,
       peak_subscribers: %{},
@@ -145,30 +148,27 @@ defmodule DiodeClient.ManagerBestChangeTest do
       {_drop_state, drop_diag} = Manager.__test_simulate_update__(drop_state)
 
       assert drop_diag.connected_count == 0,
-             "stale eu1 with reported peak 100 leaves only 2 qualifying nodes (need 3)"
+             "stale eu1 on moonbeam leaves only 2 qualifying nodes for that shell (need 3)"
 
       assert drop_diag.new_best == [us1],
-             "viable us1 should stay best despite connected quorum flicker"
+             "viable us1 should stay traffic best when eu1 is behind on diode shell"
 
       refute drop_diag.would_log
       refute drop_diag.pids_changed
     end
 
-    test "physical peak ahead of best does not clear best when reported peaks match best" do
+    test "chain peak consensus does not reshuffle traffic best when all relays are viable" do
       eu1 = spawn_conn_holder()
       us1 = spawn_conn_holder()
       as1 = spawn_conn_holder()
 
       conns = %{
-        eu1 => info(@eu1_url, eu1, 100, 100),
+        eu1 => info(@eu1_url, eu1, 105, 100),
         us1 => info(@us1_url, us1, 105, 200),
         as1 => info(@as1_url, as1, 105, 300)
       }
 
-      state =
-        base_state(conns, best: [eu1])
-        |> Map.put(:physical_peaks, peaks(105))
-        |> Map.put(:peaks, peaks(100))
+      state = base_state(conns, best: [eu1], height: 105)
 
       {_state, diag} = Manager.__test_simulate_update__(state)
 

--- a/test/manager_chain_peaks_test.exs
+++ b/test/manager_chain_peaks_test.exs
@@ -1,0 +1,78 @@
+defmodule DiodeClient.Manager.ChainPeaksTest do
+  use ExUnit.Case, async: true
+
+  alias DiodeClient.Manager.ChainPeaks
+  alias DiodeClient.Manager.Info
+  alias DiodeClient.Rlpx
+
+  @shell DiodeClient.Shell.Moonbeam
+  @opts [min_connections: 3]
+
+  defp block(n) do
+    %{"number" => Rlpx.uint2bin(n), "block_hash" => :crypto.hash(:sha256, <<n>>)}
+  end
+
+  defp info(n) do
+    %Info{
+      server_address: <<0::160>>,
+      peaks: %{@shell => block(n)}
+    }
+  end
+
+  describe "consensus_peak_for_shell/5" do
+    test "strict majority promotes to highest height" do
+      connected = for n <- [101, 101, 101, 100, 100], do: info(n)
+      last = block(100)
+
+      {peak, _} =
+        ChainPeaks.consensus_peak_for_shell(@shell, connected, last, %{}, @opts)
+
+      assert Rlpx.bin2uint(peak["number"]) == 101
+    end
+
+    test "minority ahead waits for majority" do
+      connected = for n <- [101, 101, 100, 100, 100], do: info(n)
+      last = block(100)
+
+      {peak, _} =
+        ChainPeaks.consensus_peak_for_shell(@shell, connected, last, %{}, @opts)
+
+      assert Rlpx.bin2uint(peak["number"]) == 100
+    end
+
+    test "gross stale nodes are trimmed before majority" do
+      connected = for n <- [1000, 1000, 1000, 10, 10], do: info(n)
+      last = block(900)
+
+      {peak, _} =
+        ChainPeaks.consensus_peak_for_shell(@shell, connected, last, %{}, @opts)
+
+      assert Rlpx.bin2uint(peak["number"]) == 1000
+    end
+
+    test "per-shell connected ignores other shells" do
+      conns = %{
+        :stale => %Info{
+          server_address: <<1::160>>,
+          peaks: %{@shell => block(50), DiodeClient.Shell => block(100)}
+        },
+        :a => %Info{
+          server_address: <<2::160>>,
+          peaks: %{@shell => block(100), DiodeClient.Shell => block(100)}
+        },
+        :b => %Info{
+          server_address: <<3::160>>,
+          peaks: %{@shell => block(100), DiodeClient.Shell => block(100)}
+        }
+      }
+
+      chain_peaks = %{@shell => block(100), DiodeClient.Shell => block(100)}
+
+      connected =
+        ChainPeaks.connected_for_shell(@shell, conns, chain_peaks, 2)
+
+      assert map_size(connected) == 2
+      refute Map.has_key?(connected, :stale)
+    end
+  end
+end

--- a/test/manager_test.exs
+++ b/test/manager_test.exs
@@ -87,8 +87,7 @@ defmodule DiodeClientManagerTest do
 
   describe "update and connected optimizations" do
     @tag :anvil
-    test "get_connection and get_peak linkage - peak never exceeds connection-reported peaks" do
-      # Invariant: peak will never return a block higher than any connected connection has reported
+    test "get_peak is supported by majority chain consensus" do
       shell = DiodeClient.Shell.Moonbeam
       peak = Manager.get_peak(shell)
       assert is_map(peak) or peak == nil
@@ -97,16 +96,16 @@ defmodule DiodeClientManagerTest do
         peak_num = Rlpx.bin2uint(peak["number"])
         connected = Manager.connected_connections()
 
-        for {pid, %{peaks: peaks}} <- connected do
-          conn_peak = peaks[shell]
+        supporting =
+          Enum.count(connected, fn {_pid, %{peaks: peaks}} ->
+            case peaks[shell] do
+              nil -> false
+              conn_peak -> Rlpx.bin2uint(conn_peak["number"]) >= peak_num
+            end
+          end)
 
-          if conn_peak != nil do
-            conn_num = Rlpx.bin2uint(conn_peak["number"])
-
-            assert peak_num <= conn_num,
-                   "peak #{peak_num} should be <= conn #{inspect(pid)} peak #{conn_num} (invariant)"
-          end
-        end
+        assert supporting >= div(length(connected), 2) + 1 or connected == [],
+               "peak #{peak_num} should be at or below a majority of connection reports"
       end
     end
 


### PR DESCRIPTION
## Summary
- Decouple `get_peak/1` from `get_connection/0`: per-shell strict-majority consensus (`Manager.ChainPeaks`) replaces global connected filtering and percentile trim.
- Rename internal `best` → `traffic_best` for latency-based port/object/Diode RPC routing, with Diode block + Moonbeam epoch viability gates.
- Route Moonbeam/Oasis (and other non-Diode shells) RPC through `get_chain_connection/1` so chain calls use relays at the consensus peak.

## Test plan
- [x] `mix test` (72 tests, 0 failures)
- [x] `test/manager_chain_peaks_test.exs` — supermajority, minority-at-head, stale trim, per-shell connected
- [x] `test/manager_best_change_test.exs` — traffic best sticky/reconnect behavior
- [ ] Manual: `~/dDrive/dDrive rpc` — confirm Moonbeam `chain_peaks` tracks fleet max when majority agrees

## Notes
- **Behavior change (minor):** `get_peak` may report a higher block than any `get_connection` relay has seen.
- Plan doc: `docs/plan/manager-peak-traffic-split.md`


Made with [Cursor](https://cursor.com)