### PR TITLE
Add DiodeRegistryLight read accessors and mix task

### DIFF
--- a/lib/diode_client/contracts/registry.ex
+++ b/lib/diode_client/contracts/registry.ex
@@ -1,0 +1,83 @@
+defmodule DiodeClient.Contracts.Registry do
+  @moduledoc """
+  Read-only accessors for the Moonbeam `DiodeRegistryLight` contract.
+
+  Uses on-chain view calls only (no direct storage reads).
+  """
+  alias DiodeClient.{Base16, Contracts.Utils}
+
+  @address Base16.decode("0xD78653669fd3df4dF8F3141Ffa53462121d117a4")
+  @shell DiodeClient.Shell.Moonbeam
+
+  @seconds_per_epoch 2_592_000
+
+  def address(), do: @address
+  def shell(), do: @shell
+  def seconds_per_epoch(), do: @seconds_per_epoch
+
+  def version(block \\ nil) do
+    Utils.call(@shell, @address, "Version", [], [], "uint256", block)
+  end
+
+  def epoch(block \\ nil) do
+    Utils.call(@shell, @address, "Epoch", [], [], "uint256", block)
+  end
+
+  def current_epoch(block \\ nil) do
+    Utils.call(@shell, @address, "currentEpoch", [], [], "uint256", block)
+  end
+
+  def epoch_sync_needed?(block \\ nil) do
+    epoch(block) != current_epoch(block)
+  end
+
+  def token(block \\ nil) do
+    Utils.call(@shell, @address, "Token", [], [], "address", block)
+  end
+
+  def fleet_array(block \\ nil) do
+    Utils.call(@shell, @address, "FleetArray", [], [], "address[]", block)
+  end
+
+  def relay_array(block \\ nil) do
+    Utils.call(@shell, @address, "RelayArray", [], [], "address[]", block)
+  end
+
+  def get_fleet(fleet, block \\ nil) when is_binary(fleet) do
+    [exists, current_balance, withdraw_request_size, withdrawable_balance, current_epoch, score] =
+      Utils.call(
+        @shell,
+        @address,
+        "GetFleet",
+        ["address"],
+        [fleet],
+        "(bool,uint256,uint256,uint256,uint256,uint256)",
+        block
+      )
+
+    %{
+      exists: exists in [1, true],
+      current_balance: current_balance,
+      withdraw_request_size: withdraw_request_size,
+      withdrawable_balance: withdrawable_balance,
+      current_epoch: current_epoch,
+      score: score
+    }
+  end
+
+  def get_node(fleet, node, block \\ nil)
+      when is_binary(fleet) and is_binary(node) do
+    [node_address, score] =
+      Utils.call(
+        @shell,
+        @address,
+        "GetNode",
+        ["address", "address"],
+        [fleet, node],
+        "(address,uint256)",
+        block
+      )
+
+    %{node: node_address, score: score}
+  end
+end

--- a/lib/diode_client/contracts/registry.ex
+++ b/lib/diode_client/contracts/registry.ex
@@ -3,6 +3,9 @@ defmodule DiodeClient.Contracts.Registry do
   Read-only accessors for the Moonbeam `DiodeRegistryLight` contract.
 
   Uses on-chain view calls only (no direct storage reads).
+
+  `seconds_per_epoch/0` returns a fixed protocol constant (30 days), not a value
+  read from the contract.
   """
   alias DiodeClient.{Base16, Contracts.Utils}
 
@@ -11,38 +14,102 @@ defmodule DiodeClient.Contracts.Registry do
 
   @seconds_per_epoch 2_592_000
 
+  @doc """
+  Returns the `DiodeRegistryLight` contract address on Moonbeam.
+  """
   def address(), do: @address
+
+  @doc """
+  Returns the shell used for registry view calls (`DiodeClient.Shell.Moonbeam`).
+  """
   def shell(), do: @shell
+
+  @doc """
+  Returns the protocol constant for seconds per epoch (30 days, `2_592_000`).
+
+  This value is not queried on-chain; the contract does not expose an accessor for it.
+  """
   def seconds_per_epoch(), do: @seconds_per_epoch
 
+  @doc """
+  Returns the on-chain registry version.
+
+  Optional `block` selects the block for the view call (defaults to latest).
+  """
   def version(block \\ nil) do
     Utils.call(@shell, @address, "Version", [], [], "uint256", block)
   end
 
+  @doc """
+  Returns the epoch computed from the current block timestamp.
+
+  Optional `block` selects the block for the view call (defaults to latest).
+  """
   def epoch(block \\ nil) do
     Utils.call(@shell, @address, "Epoch", [], [], "uint256", block)
   end
 
+  @doc """
+  Returns the epoch stored in contract state.
+
+  Optional `block` selects the block for the view call (defaults to latest).
+  """
   def current_epoch(block \\ nil) do
     Utils.call(@shell, @address, "currentEpoch", [], [], "uint256", block)
   end
 
+  @doc """
+  Returns whether the computed epoch differs from the stored epoch.
+
+  When `true`, an epoch sync transaction is needed on-chain.
+
+  Optional `block` selects the block for the view call (defaults to latest).
+  """
   def epoch_sync_needed?(block \\ nil) do
     epoch(block) != current_epoch(block)
   end
 
+  @doc """
+  Returns the DIODE token contract address used by the registry.
+
+  Optional `block` selects the block for the view call (defaults to latest).
+  """
   def token(block \\ nil) do
     Utils.call(@shell, @address, "Token", [], [], "address", block)
   end
 
+  @doc """
+  Returns the list of registered fleet contract addresses.
+
+  Optional `block` selects the block for the view call (defaults to latest).
+  """
   def fleet_array(block \\ nil) do
     Utils.call(@shell, @address, "FleetArray", [], [], "address[]", block)
   end
 
+  @doc """
+  Returns the list of registered relay addresses.
+
+  Optional `block` selects the block for the view call (defaults to latest).
+  """
   def relay_array(block \\ nil) do
     Utils.call(@shell, @address, "RelayArray", [], [], "address[]", block)
   end
 
+  @doc """
+  Returns fleet state for the given fleet address.
+
+  Returns a map with:
+
+    * `:exists` - whether the fleet is registered
+    * `:current_balance` - fleet balance in wei
+    * `:withdraw_request_size` - pending withdraw request size
+    * `:withdrawable_balance` - balance available to withdraw
+    * `:current_epoch` - fleet's stored epoch
+    * `:score` - fleet score
+
+  Optional `block` selects the block for the view call (defaults to latest).
+  """
   def get_fleet(fleet, block \\ nil) when is_binary(fleet) do
     [exists, current_balance, withdraw_request_size, withdrawable_balance, current_epoch, score] =
       Utils.call(
@@ -56,7 +123,7 @@ defmodule DiodeClient.Contracts.Registry do
       )
 
     %{
-      exists: exists in [1, true],
+      exists: normalize_exists(exists),
       current_balance: current_balance,
       withdraw_request_size: withdraw_request_size,
       withdrawable_balance: withdrawable_balance,
@@ -65,6 +132,16 @@ defmodule DiodeClient.Contracts.Registry do
     }
   end
 
+  @doc """
+  Returns node state for the given fleet and node addresses.
+
+  Returns a map with:
+
+    * `:node` - the node's on-chain address
+    * `:score` - the node's score
+
+  Optional `block` selects the block for the view call (defaults to latest).
+  """
   def get_node(fleet, node, block \\ nil)
       when is_binary(fleet) and is_binary(node) do
     [node_address, score] =
@@ -80,4 +157,7 @@ defmodule DiodeClient.Contracts.Registry do
 
     %{node: node_address, score: score}
   end
+
+  @doc false
+  def normalize_exists(value), do: value in [1, true]
 end

--- a/lib/mix/tasks/diode/registry.ex
+++ b/lib/mix/tasks/diode/registry.ex
@@ -25,27 +25,29 @@ defmodule Mix.Tasks.Diode.Registry do
   end
 
   defp block() do
-    shell = Registry.shell()
-    shell.peak_number(shell.peak()) - 3
+    Registry.shell().peak_number() - 3
   end
 
   def run(["version"]) do
     init()
-    print_header()
-    IO.puts("Version: #{Registry.version(block())}")
+    block = block()
+    print_header(block)
+    IO.puts("Version: #{Registry.version(block)}")
   end
 
   def run(["epoch"]) do
     init()
-    print_header()
-    print_epoch()
+    block = block()
+    print_header(block)
+    print_epoch(block)
   end
 
   def run(["fleets"]) do
     init()
-    print_header()
+    block = block()
+    print_header(block)
 
-    Registry.fleet_array(block())
+    Registry.fleet_array(block)
     |> Enum.with_index(1)
     |> Enum.each(fn {fleet, index} ->
       IO.puts("#{index}. #{Hash.printable(fleet)}")
@@ -54,9 +56,10 @@ defmodule Mix.Tasks.Diode.Registry do
 
   def run(["relays"]) do
     init()
-    print_header()
+    block = block()
+    print_header(block)
 
-    Registry.relay_array(block())
+    Registry.relay_array(block)
     |> Enum.with_index(1)
     |> Enum.each(fn {relay, index} ->
       IO.puts("#{index}. #{Hash.printable(relay)}")
@@ -65,14 +68,16 @@ defmodule Mix.Tasks.Diode.Registry do
 
   def run(["fleet", "0x" <> _ = fleet]) do
     init()
-    print_header()
-    print_fleet(Base16.decode(fleet))
+    block = block()
+    print_header(block)
+    print_fleet(Base16.decode(fleet), block)
   end
 
   def run(["node", "0x" <> _ = fleet, "0x" <> _ = node]) do
     init()
-    print_header()
-    print_node(Base16.decode(fleet), Base16.decode(node))
+    block = block()
+    print_header(block)
+    print_node(Base16.decode(fleet), Base16.decode(node), block)
   end
 
   def run(_) do
@@ -87,17 +92,15 @@ defmodule Mix.Tasks.Diode.Registry do
     """)
   end
 
-  defp print_header() do
+  defp print_header(block) do
     shell = Registry.shell()
-    block = block()
 
     IO.puts("Registry: #{Hash.printable(Registry.address())}")
     IO.puts("Shell:    #{inspect(shell)} @ block #{block}")
     IO.puts("")
   end
 
-  defp print_epoch() do
-    block = block()
+  defp print_epoch(block) do
     epoch = Registry.epoch(block)
     current_epoch = Registry.current_epoch(block)
 
@@ -108,7 +111,7 @@ defmodule Mix.Tasks.Diode.Registry do
     IO.puts("Token:             #{Hash.printable(Registry.token(block))}")
   end
 
-  defp print_fleet(fleet) do
+  defp print_fleet(fleet, block) do
     IO.puts("Fleet: #{Hash.printable(fleet)}")
     IO.puts("")
 
@@ -119,7 +122,7 @@ defmodule Mix.Tasks.Diode.Registry do
       withdrawable_balance: withdrawable_balance,
       current_epoch: current_epoch,
       score: score
-    } = Registry.get_fleet(fleet, block())
+    } = Registry.get_fleet(fleet, block)
 
     IO.puts("exists:                 #{exists}")
     IO.puts("current_balance:        #{format_amount(current_balance)}")
@@ -129,12 +132,12 @@ defmodule Mix.Tasks.Diode.Registry do
     IO.puts("score:                  #{score}")
   end
 
-  defp print_node(fleet, node) do
+  defp print_node(fleet, node, block) do
     IO.puts("Fleet: #{Hash.printable(fleet)}")
     IO.puts("Node:  #{Hash.printable(node)}")
     IO.puts("")
 
-    %{node: node_address, score: score} = Registry.get_node(fleet, node, block())
+    %{node: node_address, score: score} = Registry.get_node(fleet, node, block)
 
     IO.puts("node:  #{Hash.printable(node_address)}")
     IO.puts("score: #{score}")

--- a/lib/mix/tasks/diode/registry.ex
+++ b/lib/mix/tasks/diode/registry.ex
@@ -25,7 +25,8 @@ defmodule Mix.Tasks.Diode.Registry do
   end
 
   defp block() do
-    Registry.shell().peak_number() - 3
+    shell = Registry.shell()
+    shell.peak_number(shell.peak()) - 3
   end
 
   def run(["version"]) do
@@ -75,7 +76,7 @@ defmodule Mix.Tasks.Diode.Registry do
   end
 
   def run(_) do
-    Mix.shell().error("""
+    Mix.raise("""
     Usage:
       mix diode.registry version
       mix diode.registry epoch
@@ -84,8 +85,6 @@ defmodule Mix.Tasks.Diode.Registry do
       mix diode.registry fleet <fleet_address>
       mix diode.registry node <fleet_address> <node_address>
     """)
-
-    System.halt(1)
   end
 
   defp print_header() do
@@ -99,11 +98,13 @@ defmodule Mix.Tasks.Diode.Registry do
 
   defp print_epoch() do
     block = block()
+    epoch = Registry.epoch(block)
+    current_epoch = Registry.current_epoch(block)
 
     IO.puts("Seconds per epoch: #{Registry.seconds_per_epoch()}")
-    IO.puts("Computed epoch:    #{Registry.epoch(block)}")
-    IO.puts("Stored epoch:      #{Registry.current_epoch(block)}")
-    IO.puts("Sync needed:       #{Registry.epoch_sync_needed?(block)}")
+    IO.puts("Computed epoch:    #{epoch}")
+    IO.puts("Stored epoch:      #{current_epoch}")
+    IO.puts("Sync needed:       #{epoch != current_epoch}")
     IO.puts("Token:             #{Hash.printable(Registry.token(block))}")
   end
 

--- a/lib/mix/tasks/diode/registry.ex
+++ b/lib/mix/tasks/diode/registry.ex
@@ -1,0 +1,148 @@
+defmodule Mix.Tasks.Diode.Registry do
+  @moduledoc """
+  Read `DiodeRegistryLight` state on Moonbeam.
+
+      mix diode.registry version
+      mix diode.registry epoch
+      mix diode.registry fleets
+      mix diode.registry relays
+      mix diode.registry fleet 0x...
+      mix diode.registry node 0x...fleet... 0x...node...
+  """
+  @shortdoc "Read DiodeRegistryLight on Moonbeam"
+
+  use Mix.Task
+
+  alias DiodeClient.{Base16, Hash}
+  alias DiodeClient.Contracts.Registry
+
+  @diode_decimals 1_000_000_000_000_000_000
+
+  defp init() do
+    Logger.configure(level: :info)
+    Application.ensure_all_started(:diode_client)
+    DiodeClient.ensure_wallet()
+  end
+
+  defp block() do
+    Registry.shell().peak_number() - 3
+  end
+
+  def run(["version"]) do
+    init()
+    print_header()
+    IO.puts("Version: #{Registry.version(block())}")
+  end
+
+  def run(["epoch"]) do
+    init()
+    print_header()
+    print_epoch()
+  end
+
+  def run(["fleets"]) do
+    init()
+    print_header()
+
+    Registry.fleet_array(block())
+    |> Enum.with_index(1)
+    |> Enum.each(fn {fleet, index} ->
+      IO.puts("#{index}. #{Hash.printable(fleet)}")
+    end)
+  end
+
+  def run(["relays"]) do
+    init()
+    print_header()
+
+    Registry.relay_array(block())
+    |> Enum.with_index(1)
+    |> Enum.each(fn {relay, index} ->
+      IO.puts("#{index}. #{Hash.printable(relay)}")
+    end)
+  end
+
+  def run(["fleet", "0x" <> _ = fleet]) do
+    init()
+    print_header()
+    print_fleet(Base16.decode(fleet))
+  end
+
+  def run(["node", "0x" <> _ = fleet, "0x" <> _ = node]) do
+    init()
+    print_header()
+    print_node(Base16.decode(fleet), Base16.decode(node))
+  end
+
+  def run(_) do
+    Mix.shell().error("""
+    Usage:
+      mix diode.registry version
+      mix diode.registry epoch
+      mix diode.registry fleets
+      mix diode.registry relays
+      mix diode.registry fleet <fleet_address>
+      mix diode.registry node <fleet_address> <node_address>
+    """)
+
+    System.halt(1)
+  end
+
+  defp print_header() do
+    shell = Registry.shell()
+    block = block()
+
+    IO.puts("Registry: #{Hash.printable(Registry.address())}")
+    IO.puts("Shell:    #{inspect(shell)} @ block #{block}")
+    IO.puts("")
+  end
+
+  defp print_epoch() do
+    block = block()
+
+    IO.puts("Seconds per epoch: #{Registry.seconds_per_epoch()}")
+    IO.puts("Computed epoch:    #{Registry.epoch(block)}")
+    IO.puts("Stored epoch:      #{Registry.current_epoch(block)}")
+    IO.puts("Sync needed:       #{Registry.epoch_sync_needed?(block)}")
+    IO.puts("Token:             #{Hash.printable(Registry.token(block))}")
+  end
+
+  defp print_fleet(fleet) do
+    IO.puts("Fleet: #{Hash.printable(fleet)}")
+    IO.puts("")
+
+    %{
+      exists: exists,
+      current_balance: current_balance,
+      withdraw_request_size: withdraw_request_size,
+      withdrawable_balance: withdrawable_balance,
+      current_epoch: current_epoch,
+      score: score
+    } = Registry.get_fleet(fleet, block())
+
+    IO.puts("exists:                 #{exists}")
+    IO.puts("current_balance:        #{format_amount(current_balance)}")
+    IO.puts("withdraw_request_size:  #{format_amount(withdraw_request_size)}")
+    IO.puts("withdrawable_balance:   #{format_amount(withdrawable_balance)}")
+    IO.puts("current_epoch:          #{current_epoch}")
+    IO.puts("score:                  #{score}")
+  end
+
+  defp print_node(fleet, node) do
+    IO.puts("Fleet: #{Hash.printable(fleet)}")
+    IO.puts("Node:  #{Hash.printable(node)}")
+    IO.puts("")
+
+    %{node: node_address, score: score} = Registry.get_node(fleet, node, block())
+
+    IO.puts("node:  #{Hash.printable(node_address)}")
+    IO.puts("score: #{score}")
+  end
+
+  defp format_amount(amount) when is_integer(amount) do
+    whole = div(amount, @diode_decimals)
+    fraction = rem(amount, @diode_decimals)
+
+    "#{whole}.#{fraction |> Integer.to_string() |> String.pad_leading(18, "0")} DIODE (#{amount} wei)"
+  end
+end

--- a/test/diode_client/contracts/registry_test.exs
+++ b/test/diode_client/contracts/registry_test.exs
@@ -1,0 +1,23 @@
+defmodule DiodeClient.Contracts.RegistryTest do
+  use ExUnit.Case, async: true
+
+  alias DiodeClient.Contracts.Registry
+
+  describe "normalize_exists/1" do
+    test "returns true for ABI bool decoded as uint8 1" do
+      assert Registry.normalize_exists(1)
+    end
+
+    test "returns true for boolean true" do
+      assert Registry.normalize_exists(true)
+    end
+
+    test "returns false for ABI bool decoded as uint8 0" do
+      refute Registry.normalize_exists(0)
+    end
+
+    test "returns false for boolean false" do
+      refute Registry.normalize_exists(false)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `DiodeClient.Contracts.Registry` with call-only read accessors for the Moonbeam `DiodeRegistryLight` proxy (`GetFleet`, `GetNode`, `FleetArray`, `RelayArray`, epoch helpers, etc.).
- Add `mix diode.registry` CLI to inspect registry version, epoch state, fleet lists, and per-fleet/node traffic and stake data.

## Test plan
- [x] `mix lint`
- [x] `mix diode.registry fleet 0x0d3b95b38846fa77997e3a56ff06abdcd4d5d902` (returns fleet stake/epoch/score from Moonbeam)
- [ ] `mix diode.registry epoch`
- [ ] `mix diode.registry fleets`


Made with [Cursor](https://cursor.com)